### PR TITLE
Add support for passing merchant account ID

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,8 +92,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>8</source>
+                    <target>8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/com/shippo/model/Address.java
+++ b/src/main/java/com/shippo/model/Address.java
@@ -1,5 +1,6 @@
 package com.shippo.model;
 
+import com.shippo.net.Credentials;
 import java.util.Map;
 import java.util.List;
 
@@ -101,12 +102,12 @@ public class Address extends APIResource {
 
 	public static Address create(Map<String, Object> params) throws AuthenticationException, InvalidRequestException,
 			APIConnectionException, APIException {
-		return create(params, null);
+		return create(params, Credentials.valueOf(null));
 	}
 
-	public static Address create(Map<String, Object> params, String apiKey) throws AuthenticationException,
+	public static Address create(Map<String, Object> params, Credentials credentials) throws AuthenticationException,
 			InvalidRequestException, APIConnectionException, APIException {
-		return request(RequestMethod.POST, classURL(Address.class), params, Address.class, apiKey);
+		return request(RequestMethod.POST, classURL(Address.class), params, Address.class, credentials);
 	}
 
 	public static Address retrieve(String id) throws AuthenticationException, InvalidRequestException,

--- a/src/main/java/com/shippo/model/Batch.java
+++ b/src/main/java/com/shippo/model/Batch.java
@@ -1,5 +1,6 @@
 package com.shippo.model;
 
+import com.shippo.net.Credentials;
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -168,7 +169,7 @@ public final class Batch extends APIResource {
 		while (true) {
 			Map<String, Object> reqParams = new HashMap<String, Object>(params);
 			BatchCollection coll = request(RequestMethod.GET, classURL(Batch.class), reqParams, BatchCollection.class,
-					null);
+					Credentials.valueOf(null));
 			if (coll.array.length == 0) {
 				break;
 			}
@@ -214,7 +215,7 @@ public final class Batch extends APIResource {
 		params.put("default_servicelevel_token", serviceLevelToken);
 		params.put("label_filetype", labelFileType.toString());
 		params.put("batch_shipments", shipments);
-		return request(RequestMethod.POST, classURL(Batch.class), params, Batch.class, null);
+		return request(RequestMethod.POST, classURL(Batch.class), params, Batch.class, Credentials.valueOf(null));
 	}
 
 	public static enum ShipmentStatus {
@@ -259,7 +260,7 @@ public final class Batch extends APIResource {
 		if (objectResults != null) {
 			params.put("object_results", objectResults.toString());
 		}
-		return request(RequestMethod.GET, instanceURL(Batch.class, id), params, Batch.class, null);
+		return request(RequestMethod.GET, instanceURL(Batch.class, id), params, Batch.class, Credentials.valueOf(null));
 	}
 
 	private static class BatchShipmentId {
@@ -293,7 +294,7 @@ public final class Batch extends APIResource {
 		}
 		Map<String, Object> params = new HashMap<String, Object>();
 		params.put("__list", array);
-		return request(RequestMethod.POST, instanceURL(Batch.class, id) + "/add_shipments", params, Batch.class, null);
+		return request(RequestMethod.POST, instanceURL(Batch.class, id) + "/add_shipments", params, Batch.class, Credentials.valueOf(null));
 	}
 
 	/**
@@ -314,7 +315,7 @@ public final class Batch extends APIResource {
 		Map<String, Object> params = new HashMap<String, Object>();
 		params.put("__list", shipmentIds);
 		return request(RequestMethod.POST, instanceURL(Batch.class, id) + "/remove_shipments", params, Batch.class,
-				null);
+				Credentials.valueOf(null));
 	}
 
 	/**
@@ -328,7 +329,7 @@ public final class Batch extends APIResource {
 	 */
 	public static Batch purchase(String id)
 			throws AuthenticationException, InvalidRequestException, APIConnectionException, APIException {
-		return request(RequestMethod.POST, instanceURL(Batch.class, id) + "/purchase", null, Batch.class, null);
+		return request(RequestMethod.POST, instanceURL(Batch.class, id) + "/purchase", null, Batch.class, Credentials.valueOf(null));
 	}
 
 	public String getId() {

--- a/src/main/java/com/shippo/model/Parcel.java
+++ b/src/main/java/com/shippo/model/Parcel.java
@@ -1,5 +1,6 @@
 package com.shippo.model;
 
+import com.shippo.net.Credentials;
 import java.util.Map;
 
 import com.shippo.exception.APIConnectionException;
@@ -47,26 +48,26 @@ public class Parcel extends APIResource {
 
 	public static Parcel create(Map<String, Object> params) throws AuthenticationException, InvalidRequestException,
 			APIConnectionException, APIException {
-		return create(params, null);
+		return create(params, Credentials.valueOf(null));
 	}
 
 	public String getInstanceURL() {
 		return "";
 	}
 
-	public static Parcel create(Map<String, Object> params, String apiKey) throws AuthenticationException,
+	public static Parcel create(Map<String, Object> params, Credentials credentials) throws AuthenticationException,
 			InvalidRequestException, APIConnectionException, APIException {
-		return request(RequestMethod.POST, classURL(Parcel.class), params, Parcel.class, apiKey);
+		return request(RequestMethod.POST, classURL(Parcel.class), params, Parcel.class, credentials);
 	}
 
 	public static Parcel retrieve(String id) throws AuthenticationException, InvalidRequestException,
 			APIConnectionException, APIException {
-		return retrieve(id, null);
+		return retrieve(id, Credentials.valueOf(null));
 	}
 
-	public static Parcel retrieve(String id, String apiKey) throws AuthenticationException, InvalidRequestException,
+	public static Parcel retrieve(String id, Credentials credentials) throws AuthenticationException, InvalidRequestException,
 			APIConnectionException, APIException {
-		return request(RequestMethod.GET, instanceURL(Parcel.class, id), null, Parcel.class, apiKey);
+		return request(RequestMethod.GET, instanceURL(Parcel.class, id), null, Parcel.class, credentials);
 	}
 
 	public static ParcelCollection all(Map<String, Object> params) throws AuthenticationException,

--- a/src/main/java/com/shippo/model/Refund.java
+++ b/src/main/java/com/shippo/model/Refund.java
@@ -1,5 +1,6 @@
 package com.shippo.model;
 
+import com.shippo.net.Credentials;
 import java.util.Map;
 
 import com.shippo.exception.APIConnectionException;
@@ -22,17 +23,17 @@ public class Refund extends APIResource {
 
     public static Refund create(Map<String, Object> params) throws AuthenticationException, InvalidRequestException,
             DuplicateRefundRequestException, APIConnectionException, APIException {
-        return create(params, null);
+        return create(params, Credentials.valueOf(null));
     }
 
     public String getInstanceURL() {
         return "";
     }
 
-    public static Refund create(Map<String, Object> params, String apiKey) throws AuthenticationException,
+    public static Refund create(Map<String, Object> params, Credentials credentials) throws AuthenticationException,
             InvalidRequestException, DuplicateRefundRequestException, APIConnectionException, APIException {
         try {
-            return request(RequestMethod.POST, classURL(Refund.class), params, Refund.class, apiKey);
+            return request(RequestMethod.POST, classURL(Refund.class), params, Refund.class, credentials);
         } catch (InvalidRequestException ex) {
             if (ex.getMessage().contains(DuplicateRefundRequestException.refundMessagePattern)) {
                 throw new DuplicateRefundRequestException(ex.getMessage(), ex.getParam(), ex);

--- a/src/main/java/com/shippo/model/Shipment.java
+++ b/src/main/java/com/shippo/model/Shipment.java
@@ -1,5 +1,6 @@
 package com.shippo.model;
 
+import com.shippo.net.Credentials;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -43,18 +44,17 @@ public class Shipment extends APIResource {
 	public static Shipment create(Map<String, Object> params)
 			throws AuthenticationException, InvalidRequestException,
 			APIConnectionException, APIException {
-		return create(params, null);
+		return create(params, Credentials.valueOf(null));
 	}
 
 	public String getInstanceURL() {
 		return "";
 	}
 
-	public static Shipment create(Map<String, Object> params, String apiKey)
+	public static Shipment create(Map<String, Object> params, final Credentials credentials)
 			throws AuthenticationException, InvalidRequestException,
 			APIConnectionException, APIException {
-		return request(RequestMethod.POST, classURL(Shipment.class), params,
-				Shipment.class, apiKey);
+		return request(RequestMethod.POST, classURL(Shipment.class), params, Shipment.class, credentials);
 	}
 
 	public static RateCollection getShippingRatesSync(String object_id)

--- a/src/main/java/com/shippo/model/Transaction.java
+++ b/src/main/java/com/shippo/model/Transaction.java
@@ -1,5 +1,6 @@
 package com.shippo.model;
 
+import com.shippo.net.Credentials;
 import java.util.Map;
 
 import com.shippo.Shippo;
@@ -31,33 +32,32 @@ public class Transaction extends APIResource {
 	public static Transaction create(Map<String, Object> params)
 			throws AuthenticationException, InvalidRequestException,
 			APIConnectionException, APIException {
-		return create(params, null);
+		return create(params, Credentials.valueOf(null));
 	}
 
 	public String getInstanceURL() {
 		return "";
 	}
 
-	public static Transaction create(Map<String, Object> params, String apiKey)
+	public static Transaction create(Map<String, Object> params, Credentials credentials)
 			throws AuthenticationException, InvalidRequestException,
 			APIConnectionException, APIException {
 		return request(RequestMethod.POST, classURL(Transaction.class), params,
-				Transaction.class, apiKey);
+				Transaction.class, credentials);
 	}
 
 	public static Transaction createSync(Map<String, Object> params)
 			throws AuthenticationException, InvalidRequestException,
 			APIConnectionException, APIException, RequestTimeoutException {
-		return createSync(params, null);
+		return createSync(params, Credentials.valueOf(null));
 	}
 
-	public static Transaction createSync(Map<String, Object> params,
-			String apiKey) throws AuthenticationException,
+	public static Transaction createSync(Map<String, Object> params, final Credentials credentials) throws AuthenticationException,
 			InvalidRequestException, APIConnectionException, APIException,
 			RequestTimeoutException {
 
 		Transaction transaction = request(RequestMethod.POST,
-				classURL(Transaction.class), params, Transaction.class, apiKey);
+				classURL(Transaction.class), params, Transaction.class, credentials);
 		String object_id = transaction.objectId;
 		String status = transaction.status;
 		long startTime = System.currentTimeMillis();

--- a/src/main/java/com/shippo/net/Credentials.java
+++ b/src/main/java/com/shippo/net/Credentials.java
@@ -1,0 +1,53 @@
+package com.shippo.net;
+
+import com.shippo.Shippo;
+import java.util.Objects;
+
+public class Credentials {
+    private final String apiKey;
+    private final String accountId;
+
+    public Credentials(String apiKey, String accountId) {
+        if (apiKey == null || apiKey.isEmpty()) {
+            throw new IllegalArgumentException("API key cannot be null or empty");
+        }
+        this.apiKey = apiKey;
+        this.accountId = accountId;
+    }
+
+    public static Credentials valueOf(String apiKey) {
+        if (apiKey != null) {
+            return new Credentials(apiKey, null);
+        }
+        return new Credentials(Shippo.apiKey, null);
+    }
+
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    public String getAccountId() {
+        return accountId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Credentials that = (Credentials) o;
+        return Objects.equals(apiKey, that.apiKey) && Objects.equals(accountId, that.accountId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(apiKey, accountId);
+    }
+
+    @Override
+    public String toString() {
+        return "Credentials{" +
+                "apiKey='" + apiKey + '\'' +
+                ", accountId='" + accountId + '\'' +
+                '}';
+    }
+}

--- a/src/test/java/com/shippo/model/ShippoTest.java
+++ b/src/test/java/com/shippo/model/ShippoTest.java
@@ -43,6 +43,6 @@ public class ShippoTest {
 			public boolean test(Rate rate) {
 				return rate.isTest();
 			}
-		}).findAny().orElseThrow();
+		}).findAny().orElseThrow(() -> new RuntimeException("Did not find test rate."));
 	}
 }


### PR DESCRIPTION
This PR introduces a `Credentials` object to help propagate merchant account ID. The merchant account ID is necessary for us to migrate to a platform account, which is a requirement for using USPS.

https://docs.goshippo.com/docs/platformaccounts/platform_account_conversion/#step-4-create-a-shipment